### PR TITLE
Add header check for warnings on responses. Add client-lib and version headers on requests.

### DIFF
--- a/lib/indico.js
+++ b/lib/indico.js
@@ -25,7 +25,6 @@ var public_api = 'http://apiv2.indico.io/'
 
 indico.apiKey = false;
 indico.cloud = false;
-
 function service(name, privateCloud, apiKey) {
   if (privateCloud) {
     var prefix = 'http://' + privateCloud + '.indico.domains/';
@@ -50,12 +49,26 @@ var api_request = function(api) {
     var options = {
       method: 'POST',
       url: service(api, privateCloud, apiKey),
-      body: JSON.stringify(body)
+      body: JSON.stringify(body),
+      // TODO: Change headers to final tracking headers names
+      headers: {
+        'client-lib': 'node',
+        'version-number': '1.3.0'
+      }
     };
 
     return request(options).then(function(results){
       var res = results[0];
       var body = results[1];
+      /*
+        TODO: Make sure this matches the API headers
+       */
+      var warning = res.headers['X-warning'];
+
+      if (warning) {
+        console.warn(warning);
+      }
+
       if (res.statusCode !== 200) {
         return body;
       }

--- a/lib/indico.js
+++ b/lib/indico.js
@@ -63,7 +63,7 @@ var api_request = function(api) {
       /*
         TODO: Make sure this matches the API headers
        */
-      var warning = res.headers['X-warning'];
+      var warning = res.headers['X-Deprecation-Warning'];
 
       if (warning) {
         console.warn(warning);


### PR DESCRIPTION
Didn't add tests as these are simple enough.
Request always returns a res object with headers so this shouldn't break.

@madisonmay Could you check my naming on the headers? Not sure what the final names of them would be.

Also generally speaking the warning header is reserved for cashing inconsistencies. But I highly doubt anyone actually follows that standard.